### PR TITLE
Remove too talkative log from TangoAttrCTCtrl

### DIFF
--- a/sardana_tango/ctrl/TangoAttrCTCtrl.py
+++ b/sardana_tango/ctrl/TangoAttrCTCtrl.py
@@ -96,9 +96,6 @@ class ReadTangoAttributes:
                         extra_attribute_axis = self.devsExtraAttributes[axis]
                         if len(values) > 0:
                             dev_attr_value = values[attr]
-                            self._log.debug("For attribute %s axis %d [%s]"
-                                            % (str(attr), axis,
-                                               str(dev_attr_value)))
                             if dev_attr_value.has_failed:
                                 # In case of Attribute error
                                 VALUE = tango.DevFailed(


### PR DESCRIPTION
@jairomoldes discovered that TangoAttrCTCtrl is too talkative.
1e6515b1acc7c accidentally left a log message which is not necessary - remove it.

I'll auto-merge it, cause it is a trivial change.