### PR TITLE
Improve error messages (fix #15)

### DIFF
--- a/sardana_tango/ctrl/TangoAttrCTCtrl.py
+++ b/sardana_tango/ctrl/TangoAttrCTCtrl.py
@@ -141,11 +141,11 @@ class TangoAttrCTController(ReadTangoAttributes, CounterTimerController):
     +) TangoAttribute - Tango attribute to retrieve the value of the counter
     +) Formula - Formula to evaluate using 'VALUE' as the tango attribute value
     As examples you could have:
-    ch1.TangoExtraAttribute = 'my/tango/device/attribute1'
+    ch1.TangoAttribute = 'my/tango/device/attribute1'
     ch1.Formula = '-1 * VALUE'
-    ch2.TangoExtraAttribute = 'my/tango/device/attribute2'
+    ch2.TangoAttribute = 'my/tango/device/attribute2'
     ch2.Formula = 'math.sqrt(VALUE)'
-    ch3.TangoExtraAttribute = 'my_other/tango/device/attribute1'
+    ch3.TangoAttribute = 'my_other/tango/device/attribute1'
     ch3.Formula = 'math.cos(VALUE)'
     """
 

--- a/sardana_tango/ctrl/TangoAttrIORCtrl.py
+++ b/sardana_tango/ctrl/TangoAttrIORCtrl.py
@@ -76,9 +76,9 @@ class TangoAttrIORController(IORegisterController):
     Each IORegisters _MUST_HAVE_ extra attributes:
     +) TangoAttribute - Tango attribute to retrieve the value of the IORegister
         As examples you could have:
-        ch1.TangoExtraAttribute = 'my/tango/device/attribute1'
-        ch2.TangoExtraAttribute = 'my/tango/device/attribute2'
-        ch3.TangoExtraAttribute = 'my_other/tango/device/attribute1'
+        ch1.TangoAttribute = 'my/tango/device/attribute1'
+        ch2.TangoAttribute = 'my/tango/device/attribute2'
+        ch3.TangoAttribute = 'my_other/tango/device/attribute1'
     Each IORegisters _MAY_HAVE_ extra attributes:
     +) Labels - Human readable tag followed to the corresponding position
             (integer) value.

--- a/sardana_tango/ctrl/TangoAttrIORCtrl.py
+++ b/sardana_tango/ctrl/TangoAttrIORCtrl.py
@@ -222,10 +222,10 @@ class TangoAttrIORController(IORegisterController):
                         return positions[calibration.index(fussyPos)]
                 # if the loop ends, current value is not in the fussy areas.
                 self.devsExtraAttributes[axis][READFAILED] = True
-                msg = 'Position out of calibration bounds. ' \
+                msg = 'Value ({}) out of calibration bounds. ' \
                       'Please review ior calibration or write a valid value ' \
-                      'to the underlying tango attribute: %s.%s' % (
-                          self.devsExtraAttributes[axis][DEVICE], attr)
+                      'to the underlying tango attribute: {}.{}'.format(
+                          value, self.devsExtraAttributes[axis][DEVICE], attr)
                 raise ValueError(msg)
             else:
                 raise Exception(

--- a/sardana_tango/ctrl/TangoAttrIORCtrl.py
+++ b/sardana_tango/ctrl/TangoAttrIORCtrl.py
@@ -169,9 +169,9 @@ class TangoAttrIORController(IORegisterController):
                     "Not yet configured the Tango Attribute, "
                     "or cannot proxy it")
         if not lcalibration == 0 and not llabels == lcalibration:
-            return(State.Disable,
-                   "Bad configuration of the extra attributes, "
-                   "this cannot be operated")
+            return (State.Disable,
+                    "Bad configuration of the extra attributes, "
+                    "this cannot be operated")
         else:
             dev_state = dev_proxy.state()
             if readFailed and not dev_state == DevState.MOVING:


### PR DESCRIPTION
This PR Addresses the error handling and messaging pointed out by @marceloalcocer in https://github.com/ALBA-Synchrotron/sardana-tango/issues/15.

An improved explanation message has been included in the case the value is out of the current ior calibration and the local exception handling now re-raises the exception including the message (before it was returning `None` and it was `_read_axis_value` of `PoolController` raising the `ValueError` general exception). Now the output is the following:
```
Door_macroserver_1 [100]: dev = tango.DeviceProxy("bl16/ct/bl16ghs01")

Door_macroserver_1 [101]: dev.dummy_MFC_01_set
        Result [101]: 5.0

Door_macroserver_1 [102]: tango_ior01.tangoAttribute
        Result [102]: 'bl16/ct/bl16ghs01/dummy_MFC_01_set'

Door_macroserver_1 [103]: tango_ior01.calibration
        Result [103]: '[[0.9, 1.0, 1.1], [1.9, 2.0, 2.1], [2.9, 3.0, 3.1]]'

Door_macroserver_1 [103]: tango_ior01.value
PyDs_PythonError: ValueError: Value (5.0) out of calibration bounds. Please review ior calibration or write a valid value to the underlying tango attribute: bl16/ct/bl16ghs01.dummy_MFC_01_set
```
I started with this one but probably other error messages in sardana_tango controllers could be improved as well.
